### PR TITLE
Add Byte Search Overloads

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,2 @@
+mode: ContinuousDeployment
+branches: {}

--- a/src/IronRe2/Captures.cs
+++ b/src/IronRe2/Captures.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -12,7 +13,7 @@ namespace IronRe2
         {
         }
 
-        internal Captures(byte[] haystack, ByteRange[] ranges)
+        internal Captures(ReadOnlyMemory<byte> haystack, ByteRange[] ranges)
             : base(haystack, ranges[0])
         {
             _ranges = ranges;

--- a/src/IronRe2/Captures.cs
+++ b/src/IronRe2/Captures.cs
@@ -37,7 +37,7 @@ namespace IronRe2
                 yield return this[i];
             }
         }
-        
+
         IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 
         /// <summary>

--- a/src/IronRe2/IronRe2.csproj
+++ b/src/IronRe2/IronRe2.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IronRe2-Batteries.OSX" Version="0.1.1-cre2-named-caps-0004" />
-    <PackageReference Include="IronRe2-Batteries.Linux" Version="0.1.1-cre2-named-caps-0004" />
-    <PackageReference Include="IronRe2-Batteries.Windows" Version="0.1.1-cre2-named-caps-0004" />
+    <PackageReference Include="IronRe2-Batteries.OSX" Version="0.2.0" />
+    <PackageReference Include="IronRe2-Batteries.Linux" Version="0.2.0" />
+    <PackageReference Include="IronRe2-Batteries.Windows" Version="0.2.0" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 </Project>

--- a/src/IronRe2/IronRe2.csproj
+++ b/src/IronRe2/IronRe2.csproj
@@ -2,11 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="IronRe2-Batteries.OSX" Version="0.1.0" />
     <PackageReference Include="IronRe2-Batteries.Linux" Version="0.1.0" />
     <PackageReference Include="IronRe2-Batteries.Windows" Version="0.1.0" />
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 </Project>

--- a/src/IronRe2/IronRe2.csproj
+++ b/src/IronRe2/IronRe2.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>Latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IronRe2/IronRe2.csproj
+++ b/src/IronRe2/IronRe2.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IronRe2-Batteries.OSX" Version="0.1.0" />
-    <PackageReference Include="IronRe2-Batteries.Linux" Version="0.1.0" />
-    <PackageReference Include="IronRe2-Batteries.Windows" Version="0.1.0" />
+    <PackageReference Include="IronRe2-Batteries.OSX" Version="0.1.1-cre2-named-caps-0004" />
+    <PackageReference Include="IronRe2-Batteries.Linux" Version="0.1.1-cre2-named-caps-0004" />
+    <PackageReference Include="IronRe2-Batteries.Windows" Version="0.1.1-cre2-named-caps-0004" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 </Project>

--- a/src/IronRe2/Match.cs
+++ b/src/IronRe2/Match.cs
@@ -58,7 +58,7 @@ namespace IronRe2
         {
             get
             {
-                if (!Matched)
+                if (!Matched || Start == End)
                 {
                     return string.Empty;
                 }

--- a/src/IronRe2/NamedCaptureEnumerable.cs
+++ b/src/IronRe2/NamedCaptureEnumerable.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace IronRe2
+{
+    /// <summary>
+    /// Enumerable of named capture groups
+    /// </summary>
+    internal class NamedCaptureEnumerable : IEnumerable<NamedCaptureGroup>
+    {
+        private Regex _regex;
+
+        public NamedCaptureEnumerable(Regex regex)
+        {
+            _regex = regex;
+        }
+
+        public IEnumerator<NamedCaptureGroup> GetEnumerator()
+        {
+            return new NamedCaptureEnumerator(_regex);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/IronRe2/NamedCaptureEnumerator.cs
+++ b/src/IronRe2/NamedCaptureEnumerator.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace IronRe2
+{
+    /// <summary>
+    /// Enumerator for walking an interator of named capture groups.
+    /// </summary>
+    internal class NamedCaptureEnumerator : UnmanagedResource, IEnumerator<NamedCaptureGroup>
+    {
+        public NamedCaptureEnumerator(Regex regex)
+            : base(Re2Ffi.cre2_named_groups_iter_new(regex.RawHandle))
+        {
+        }
+
+        protected override void Free(IntPtr handle)
+        {
+            Re2Ffi.cre2_named_groups_iter_delete(handle);
+        }
+
+
+        /// <summary>
+        ///  The current named capture this enumerator is pointing at.
+        /// </summary>
+        /// <value>
+        /// Named capture information, or null if the enumerator isn't pointing
+        /// at a valid item.
+        /// </value>
+        public NamedCaptureGroup Current { get; private set; }
+
+        object IEnumerator.Current => Current;
+
+
+        /// <summary>
+        ///  Advance the enumerator
+        /// </summary>
+        /// <returns>True if <see cref="Current" /> now points to a valid
+        /// <see cref="NamedCaptureGroup" /></returns>
+        public unsafe bool MoveNext()
+        {
+            if (Re2Ffi.cre2_named_groups_iter_next(RawHandle, out var namePtr, out var index))
+            {
+                var name = Marshal.PtrToStringAnsi(new IntPtr(namePtr));
+                Current = new NamedCaptureGroup(name, index);
+                return true;
+            }
+            else
+            {
+                Current = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Resetting this enumerator isn't supported
+        /// </summary>
+        public void Reset()
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/IronRe2/NamedCaptureGroup.cs
+++ b/src/IronRe2/NamedCaptureGroup.cs
@@ -1,0 +1,24 @@
+namespace IronRe2
+{
+    /// <summary>
+    ///  Named Capture Group Information
+    /// </summary>
+    public class NamedCaptureGroup
+    {
+        internal NamedCaptureGroup(string name, int index)
+        {
+            Name = name;
+            Index = index;
+        }
+
+        /// <summary>
+        ///  The name of the capture group
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The index in the captures array for this
+        /// </summary>
+        public int Index { get; }
+    }
+}

--- a/src/IronRe2/Re2Ffi.cs
+++ b/src/IronRe2/Re2Ffi.cs
@@ -186,7 +186,7 @@ namespace IronRe2
         /* construction and destruction */
         [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
         public static extern cre2_regexp_t_ptr cre2_new(
-            [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex=1)]byte[] pattern,
+            in byte pattern,
             int pattern_len,
             cre2_options_t_ptr opt);
 

--- a/src/IronRe2/Re2Ffi.cs
+++ b/src/IronRe2/Re2Ffi.cs
@@ -290,7 +290,7 @@ namespace IronRe2
         /// </summary>
         [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
         public static extern UIntPtr cre2_set_match(
-            cre2_set_t_ptr set, byte[] text, UIntPtr text_len,
+            cre2_set_t_ptr set, in byte text, UIntPtr text_len,
             [Out, MarshalAs(UnmanagedType.LPArray)]int[] match, UIntPtr match_len);
     }
 }

--- a/src/IronRe2/Re2Ffi.cs
+++ b/src/IronRe2/Re2Ffi.cs
@@ -212,6 +212,7 @@ namespace IronRe2
         [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
         public static extern cre2_named_groups_iter_t_ptr cre2_named_groups_iter_new(cre2_regexp_t_ptr re);
         [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.I1)]
         public static unsafe extern bool cre2_named_groups_iter_next(cre2_named_groups_iter_t_ptr iter, out char * name, out int index);
         [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
         public static extern void cre2_named_groups_iter_delete(cre2_named_groups_iter_t_ptr iter);

--- a/src/IronRe2/Re2Ffi.cs
+++ b/src/IronRe2/Re2Ffi.cs
@@ -21,19 +21,19 @@ namespace IronRe2
          ** ----------------------------------------------------------------- */
 
 
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr cre2_version_string();
 
 
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr cre2_version_interface_current();
 
 
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr cre2_version_interface_revision();
 
 
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr cre2_version_interface_age();
 
 
@@ -41,79 +41,81 @@ namespace IronRe2
          ** Regular expressions configuration options.
          ** ----------------------------------------------------------------- */
 
-        public enum cre2_encoding_t {
-           CRE2_UNKNOWN  = 0,    /* should never happen */
-           CRE2_UTF8 = 1,
-           CRE2_Latin1   = 2
+        public enum cre2_encoding_t
+        {
+            CRE2_UNKNOWN = 0,    /* should never happen */
+            CRE2_UTF8 = 1,
+            CRE2_Latin1 = 2
         }
 
 
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern  cre2_options_t_ptr cre2_opt_new();
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern  void cre2_opt_delete(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern cre2_options_t_ptr cre2_opt_new();
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_delete(cre2_options_t_ptr opt);
 
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_posix_syntax    (cre2_options_t_ptr opt, int flag);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_longest_match   (cre2_options_t_ptr opt, int flag);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_log_errors      (cre2_options_t_ptr opt, int flag);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_literal     (cre2_options_t_ptr opt, int flag);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_never_nl        (cre2_options_t_ptr opt, int flag);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_dot_nl      (cre2_options_t_ptr opt, int flag);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_never_capture   (cre2_options_t_ptr opt, int flag);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_case_sensitive  (cre2_options_t_ptr opt, int flag);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_perl_classes    (cre2_options_t_ptr opt, int flag);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_word_boundary   (cre2_options_t_ptr opt, int flag);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_one_line        (cre2_options_t_ptr opt, int flag);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_max_mem     (cre2_options_t_ptr opt, [MarshalAs(UnmanagedType.I8)]long m);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void cre2_opt_set_encoding        (cre2_options_t_ptr opt, cre2_encoding_t enc);
-     
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int cre2_opt_posix_syntax     (cre2_options_t_ptr opt);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int cre2_opt_longest_match        (cre2_options_t_ptr opt);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int cre2_opt_log_errors       (cre2_options_t_ptr opt);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int cre2_opt_literal          (cre2_options_t_ptr opt);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int cre2_opt_never_nl         (cre2_options_t_ptr opt);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int cre2_opt_dot_nl           (cre2_options_t_ptr opt);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int cre2_opt_never_capture        (cre2_options_t_ptr opt);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int cre2_opt_case_sensitive       (cre2_options_t_ptr opt);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int cre2_opt_perl_classes     (cre2_options_t_ptr opt);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int cre2_opt_word_boundary        (cre2_options_t_ptr opt);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int cre2_opt_one_line         (cre2_options_t_ptr opt);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        [return:MarshalAs(UnmanagedType.I8)]
-        public static extern long cre2_opt_max_mem      (cre2_options_t_ptr opt);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern cre2_encoding_t cre2_opt_encoding (cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_posix_syntax(cre2_options_t_ptr opt, int flag);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_longest_match(cre2_options_t_ptr opt, int flag);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_log_errors(cre2_options_t_ptr opt, int flag);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_literal(cre2_options_t_ptr opt, int flag);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_never_nl(cre2_options_t_ptr opt, int flag);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_dot_nl(cre2_options_t_ptr opt, int flag);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_never_capture(cre2_options_t_ptr opt, int flag);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_case_sensitive(cre2_options_t_ptr opt, int flag);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_perl_classes(cre2_options_t_ptr opt, int flag);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_word_boundary(cre2_options_t_ptr opt, int flag);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_one_line(cre2_options_t_ptr opt, int flag);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_max_mem(cre2_options_t_ptr opt, [MarshalAs(UnmanagedType.I8)]long m);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_opt_set_encoding(cre2_options_t_ptr opt, cre2_encoding_t enc);
+
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int cre2_opt_posix_syntax(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int cre2_opt_longest_match(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int cre2_opt_log_errors(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int cre2_opt_literal(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int cre2_opt_never_nl(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int cre2_opt_dot_nl(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int cre2_opt_never_capture(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int cre2_opt_case_sensitive(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int cre2_opt_perl_classes(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int cre2_opt_word_boundary(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int cre2_opt_one_line(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.I8)]
+        public static extern long cre2_opt_max_mem(cre2_options_t_ptr opt);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern cre2_encoding_t cre2_opt_encoding(cre2_options_t_ptr opt);
 
         /** --------------------------------------------------------------------
          ** Precompiled regular expressions.
          ** ----------------------------------------------------------------- */
 
         [StructLayout(LayoutKind.Sequential)]
-        public struct cre2_string_t {
+        public struct cre2_string_t
+        {
             public IntPtr data;
             public int length;
         };
@@ -123,7 +125,8 @@ namespace IronRe2
         /// "enum ErrorCode" in the file "re2.h" of the original RE2
         /// distribution.
         /// </summary>
-        public enum cre2_error_code_t {
+        public enum cre2_error_code_t
+        {
             CRE2_NO_ERROR = 0,
             /// <summary>
             /// unexpected error
@@ -164,7 +167,7 @@ namespace IronRe2
             /// <summary>
             /// bad repetition operator
             /// </summary>
-            CRE2_ERROR_REPEAT_OP,	
+            CRE2_ERROR_REPEAT_OP,
             /// <summary>
             /// bad perl operator
             /// </summary>
@@ -185,43 +188,43 @@ namespace IronRe2
 
 
         /* construction and destruction */
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern cre2_regexp_t_ptr cre2_new(
             in byte pattern,
             int pattern_len,
             cre2_options_t_ptr opt);
 
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern void cre2_delete(cre2_regexp_t_ptr re);
 
 
         /* regular expression inspection */
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr cre2_pattern(cre2_regexp_t_ptr re);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern cre2_error_code_t cre2_error_code(cre2_regexp_t_ptr re);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern int cre2_num_capturing_groups(cre2_regexp_t_ptr re);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern int cre2_find_named_capturing_groups(
             cre2_regexp_t_ptr re, [MarshalAs(UnmanagedType.LPStr)]string name);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern int cre2_program_size(cre2_regexp_t_ptr re);
 
 
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern cre2_named_groups_iter_t_ptr cre2_named_groups_iter_new(cre2_regexp_t_ptr re);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static unsafe extern bool cre2_named_groups_iter_next(cre2_named_groups_iter_t_ptr iter, out char * name, out int index);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        public static unsafe extern bool cre2_named_groups_iter_next(cre2_named_groups_iter_t_ptr iter, out char* name, out int index);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern void cre2_named_groups_iter_delete(cre2_named_groups_iter_t_ptr iter);
 
 
         /* invalidated by further re use */
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr cre2_error_string(cre2_regexp_t_ptr re);
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern void cre2_error_arg(
             cre2_regexp_t_ptr re,
             [In, Out]ref cre2_string_t arg);
@@ -231,30 +234,31 @@ namespace IronRe2
          ** Main matching functions.
          ** ----------------------------------------------------------------- */
 
-         public enum cre2_anchor_t {
-            CRE2_UNANCHORED   = 1,
+        public enum cre2_anchor_t
+        {
+            CRE2_UNANCHORED = 1,
             CRE2_ANCHOR_START = 2,
-            CRE2_ANCHOR_BOTH  = 3
+            CRE2_ANCHOR_BOTH = 3
         }
 
         /// <returns>
         /// 0  for  no  match, 1 for  successful matching
         /// </returns>
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern int cre2_match(cre2_regexp_t_ptr re,
             byte* text, int textlen,
             int startpos, int endpos, cre2_anchor_t anchor,
-            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex=6)]cre2_string_t[] match, int nmatch);
+            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 6)]cre2_string_t[] match, int nmatch);
 
         /// <returns>
         /// 0  for  no  match, 1 for  successful
         /// matching, 2 for wrong regexp
         /// </returns>
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern int cre2_easy_match(
             in byte pattern, int pattern_len,
             in byte text, int text_len,
-			[Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex=5)]cre2_string_t[] match, int nmatch);
+            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)]cre2_string_t[] match, int nmatch);
 
 
         /** --------------------------------------------------------------------
@@ -264,41 +268,41 @@ namespace IronRe2
         /// <summary>
         /// RE2::Set constructor
         /// </summary>
-        
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern cre2_set_t_ptr cre2_set_new(cre2_options_t_ptr opt, cre2_anchor_t anchor);
         /// <summary>
         /// RE2::Set destructor
         /// </summary>
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern void      cre2_set_delete(cre2_set_t_ptr set);
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void cre2_set_delete(cre2_set_t_ptr set);
         /// <summary>
         /// Add a regex to the set. If invalid: store error message in error buffer.
         /// Returns the index associated to this regex, -1 on error
         /// </summary>
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern int cre2_set_add(
             cre2_set_t_ptr set,
-            [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex=2)]byte[] pattern, UIntPtr pattern_len,
-            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex=4)]byte[] error, UIntPtr error_len);
+            [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]byte[] pattern, UIntPtr pattern_len,
+            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)]byte[] error, UIntPtr error_len);
         /// <summary>
         /// Add pattern without NULL byte. Discard error message.
         /// Returns the index associated to this regex, -1 on error
         /// </summary>
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern int cre2_set_add_simple(
             cre2_set_t_ptr set, [MarshalAs(UnmanagedType.LPStr)]string pattern);
         /// <summary>
         /// Compile the regex set into a DFA. Must be called after add and before match.
         /// Returns 1 on success, 0 on error
         /// </summary>
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern int cre2_set_compile(cre2_set_t_ptr set);
         /// <summary>
         /// Match the set of regex against text and store indices of matching regexes in match array.
         /// Returns the number of regexes which match.
         /// </summary>
-        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        [DllImport("cre2", CallingConvention = CallingConvention.Cdecl)]
         public static extern UIntPtr cre2_set_match(
             cre2_set_t_ptr set, in byte text, UIntPtr text_len,
             [Out, MarshalAs(UnmanagedType.LPArray)]int[] match, UIntPtr match_len);

--- a/src/IronRe2/Re2Ffi.cs
+++ b/src/IronRe2/Re2Ffi.cs
@@ -231,8 +231,8 @@ namespace IronRe2
         /// 0  for  no  match, 1 for  successful matching
         /// </returns>
         [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int cre2_match(cre2_regexp_t_ptr re,
-            [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex=1)]byte[] text, int textlen,
+        public static unsafe extern int cre2_match(cre2_regexp_t_ptr re,
+            byte* text, int textlen,
             int startpos, int endpos, cre2_anchor_t anchor,
             [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex=6)]cre2_string_t[] match, int nmatch);
 

--- a/src/IronRe2/Re2Ffi.cs
+++ b/src/IronRe2/Re2Ffi.cs
@@ -242,8 +242,8 @@ namespace IronRe2
         /// </returns>
         [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
         public static extern int cre2_easy_match(
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=1)]byte[] pattern, int pattern_len,
-			[MarshalAs(UnmanagedType.LPArray, SizeParamIndex=3)]byte[] text, int text_len,
+            in byte pattern, int pattern_len,
+            in byte text, int text_len,
 			[Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex=5)]cre2_string_t[] match, int nmatch);
 
 

--- a/src/IronRe2/Re2Ffi.cs
+++ b/src/IronRe2/Re2Ffi.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using cre2_regexp_t_ptr = System.IntPtr;
 using cre2_set_t_ptr = System.IntPtr;
 using cre2_options_t_ptr = System.IntPtr;
+using cre2_named_groups_iter_t_ptr = System.IntPtr;
 
 namespace IronRe2
 {
@@ -206,6 +207,14 @@ namespace IronRe2
             cre2_regexp_t_ptr re, [MarshalAs(UnmanagedType.LPStr)]string name);
         [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
         public static extern int cre2_program_size(cre2_regexp_t_ptr re);
+
+
+        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        public static extern cre2_named_groups_iter_t_ptr cre2_named_groups_iter_new(cre2_regexp_t_ptr re);
+        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        public static unsafe extern bool cre2_named_groups_iter_next(cre2_named_groups_iter_t_ptr iter, out char * name, out int index);
+        [DllImport("cre2", CallingConvention=CallingConvention.Cdecl)]
+        public static extern void cre2_named_groups_iter_delete(cre2_named_groups_iter_t_ptr iter);
 
 
         /* invalidated by further re use */

--- a/src/IronRe2/Regex.cs
+++ b/src/IronRe2/Regex.cs
@@ -195,9 +195,25 @@ namespace IronRe2
         public Captures Captures(string haystack)
         {
             var hayBytes = Encoding.UTF8.GetBytes(haystack);
-            var ranges = RawMatch(hayBytes, CaptureGroupCount + 1);
+            return Captures(hayBytes);
+        }
+
+        /// <summary>
+        /// Find with Captures
+        /// <para>
+        /// This is the most expensive of the match options but provides the
+        /// richest information about the match. The returned
+        /// <see cref="IronRe2.Captures" /> object contains the match position
+        /// of each of the regex's capturing groups.
+        /// </para>
+        /// </summary>
+        /// <param name="haystack">The string to search for the pattern</param>
+        /// <returns>The captures data</returns>
+        public Captures Captures(ReadOnlyMemory<byte> haystack)
+        {
+            var ranges = RawMatch(haystack.Span, CaptureGroupCount + 1);
             return (ranges.Length == 0) ?
-                IronRe2.Captures.Empty : new Captures(hayBytes, ranges);
+                IronRe2.Captures.Empty : new Captures(haystack, ranges);
         }
 
         /// <summary>

--- a/src/IronRe2/Regex.cs
+++ b/src/IronRe2/Regex.cs
@@ -236,6 +236,15 @@ namespace IronRe2
         }
 
         /// <summary>
+        /// Get an Iterator over the Named Captures in the Pattern
+        /// </summary>
+        /// <returns>An enumerable of the named capture groups</returns>
+        public IEnumerable<NamedCaptureGroup> NamedCaptures()
+        {
+            return new NamedCaptureEnumerable(this);
+        }
+
+        /// <summary>
         /// Find with Captures
         /// <para>
         /// This is the most expensive of the match options but provides the

--- a/src/IronRe2/Regex.cs
+++ b/src/IronRe2/Regex.cs
@@ -73,7 +73,7 @@ namespace IronRe2
             var handle = Re2Ffi.cre2_new(
                 in MemoryMarshal.GetReference(patternBytes), patternBytes.Length,
                 opts?.RawHandle ?? IntPtr.Zero);
-            
+
             // Check to see if there was an error compiling this expression
             var errorCode = Re2Ffi.cre2_error_code(handle);
             if (errorCode != Re2Ffi.cre2_error_code_t.CRE2_NO_ERROR)
@@ -114,7 +114,7 @@ namespace IronRe2
         /// </summary>
         public int CaptureGroupCount =>
             Re2Ffi.cre2_num_capturing_groups(RawHandle);
-        
+
         /// <summary>
         ///  Find a capture group index by name
         /// </summary>
@@ -144,7 +144,7 @@ namespace IronRe2
         public unsafe bool IsMatch(ReadOnlySpan<byte> haystack)
         {
             var captures = Array.Empty<Re2Ffi.cre2_string_t>();
-            
+
             fixed (byte* hayBytesPtr = haystack)
             {
                 // TODO: Support anchor as a parameter
@@ -288,7 +288,7 @@ namespace IronRe2
         /// <returns>The captures data</returns>
         public Captures Captures(ReadOnlyMemory<byte> haystack) =>
             Captures(haystack, 0);
-        
+
         /// <summary>
         /// Find with Captures, starting from a given offset
         /// <para>
@@ -467,7 +467,7 @@ namespace IronRe2
         public unsafe static Match Find(
             ReadOnlySpan<byte> pattern, ReadOnlyMemory<byte> haystack)
         {
-            var captures = new [] {
+            var captures = new[] {
                 new Re2Ffi.cre2_string_t()
             };
 

--- a/src/IronRe2/Regex.cs
+++ b/src/IronRe2/Regex.cs
@@ -23,7 +23,7 @@ namespace IronRe2
         /// Create a regular expression from a given pattern, encoded as UTF8
         /// </summary>
         /// <param name="pattern">The pattern to match, as bytes</param>
-        public Regex(byte[] pattern)
+        public Regex(ReadOnlySpan<byte> pattern)
             : base(Compile(pattern, null))
         {
         }
@@ -43,7 +43,7 @@ namespace IronRe2
         /// </summary>
         /// <param name="pattern">The pattern to match, as bytes</param>
         /// <param name="options">The compilation options to use</param>
-        public Regex(byte[] pattern, Options options)
+        public Regex(ReadOnlySpan<byte> pattern, Options options)
             : base(Compile(pattern, options))
         {
         }
@@ -67,10 +67,10 @@ namespace IronRe2
         /// <returns>
         /// The raw handle to the Regex, or throws on compilation failure
         /// </returns>
-        private static IntPtr Compile(byte[] patternBytes, Options opts)
+        private static IntPtr Compile(ReadOnlySpan<byte> patternBytes, Options opts)
         {
             var handle = Re2Ffi.cre2_new(
-                patternBytes, patternBytes.Length,
+                in MemoryMarshal.GetReference(patternBytes), patternBytes.Length,
                 opts?.RawHandle ?? IntPtr.Zero);
             
             // Check to see if there was an error compiling this expression

--- a/src/IronRe2/RegexSet.cs
+++ b/src/IronRe2/RegexSet.cs
@@ -140,10 +140,21 @@ namespace IronRe2
         public SetMatch Match(string haystack)
         {
             var hayBytes = Encoding.UTF8.GetBytes(haystack);
+            return Match(hayBytes);
+        }
+
+        /// <summary>
+        /// Match the patterns against he given search text and return
+        /// information about the matching patterns.
+        /// </summary>
+        /// <param name="haystack">The text to search</param>
+        /// <returns>An object representing the state of the matches</returns>
+        public SetMatch Match(ReadOnlySpan<byte> haystack)
+        {
             var matchIndices = new int[Count];
             var matchCount = Re2Ffi.cre2_set_match(
                 RawHandle,
-                hayBytes, new UIntPtr((uint)hayBytes.Length),
+                in MemoryMarshal.GetReference(haystack), new UIntPtr((uint)haystack.Length),
                 matchIndices, new UIntPtr((uint)matchIndices.Length));
             Array.Resize(ref matchIndices, (int)matchCount);
             return new SetMatch(matchCount, matchIndices);

--- a/src/IronRe2/RegexSet.cs
+++ b/src/IronRe2/RegexSet.cs
@@ -129,7 +129,7 @@ namespace IronRe2
         /// <summary>
         /// Returns the number of patterns in this set
         /// </summary>
-        public int Count {get;}
+        public int Count { get; }
 
         /// <summary>
         /// Match the patterns against he given search text and return

--- a/src/IronRe2/UnmanagedResource.cs
+++ b/src/IronRe2/UnmanagedResource.cs
@@ -5,7 +5,7 @@ namespace IronRe2
 {
     public abstract class UnmanagedResource : IDisposable
     {
-        
+
         // Raw handle to the underlying unmanaged resource
         private IntPtr _rawHandle;
 
@@ -13,7 +13,7 @@ namespace IronRe2
         {
             _rawHandle = rawHandle;
         }
-        
+
         ~UnmanagedResource()
         {
             Dispose(false);

--- a/test/IronRe2.Tests/MetaTests.cs
+++ b/test/IronRe2.Tests/MetaTests.cs
@@ -8,24 +8,24 @@ namespace IronRe2.Tests
         [Fact]
         public void MetaGetVersionString()
         {
-        //Given
-        
-        //When
+            //Given
+
+            //When
             var version = Meta.VersionString;
-        
-        //Then
+
+            //Then
             Assert.Equal("0.0.0", version);
         }
 
         [Fact]
         public void MetaGetVersion()
         {
-        //Given
-        
-        //When
+            //Given
+
+            //When
             var version = Meta.Version;
-        
-        //Then
+
+            //Then
             Assert.Equal(0, version.current);
             Assert.Equal(0, version.revision);
             Assert.Equal(0, version.age);

--- a/test/IronRe2.Tests/OptionsTests.cs
+++ b/test/IronRe2.Tests/OptionsTests.cs
@@ -7,10 +7,10 @@ namespace IronRe2.Tests
         [Fact]
         public void OptionsCreateHasDefaultValues()
         {
-        //Given
+            //Given
             var options = new Options();
 
-        //Then
+            //Then
             Assert.False(options.PosixSyntax);
             Assert.False(options.LongestMatch);
             Assert.True(options.LogErrors);
@@ -25,17 +25,17 @@ namespace IronRe2.Tests
             Assert.False(options.OneLine);
 
             Assert.Equal(RegexEncoding.Utf8, options.Encoding);
-            Assert.Equal(8<<20, options.MaxMemory);
+            Assert.Equal(8 << 20, options.MaxMemory);
         }
 
 
         [Fact]
         public void OptionsSetValuesStoresValues()
         {
-        //Given
+            //Given
             var options = new Options();
-        
-        //When
+
+            //When
             options.PosixSyntax = true;
             options.LongestMatch = true;
             options.LogErrors = false;
@@ -50,7 +50,7 @@ namespace IronRe2.Tests
             options.Encoding = RegexEncoding.Latin1;
             options.MaxMemory = 700;
 
-        //Then
+            //Then
             Assert.True(options.PosixSyntax);
             Assert.True(options.LongestMatch);
             Assert.False(options.LogErrors);

--- a/test/IronRe2.Tests/RegexSetTests.cs
+++ b/test/IronRe2.Tests/RegexSetTests.cs
@@ -8,38 +8,39 @@ namespace IronRe2.Tests
         [Fact]
         public void RegexSetCreate()
         {
-        //Given
-            var patterns = new [] {
+            //Given
+            var patterns = new[] {
                 @"hello world",
                 @".+",
                 @"(\d{2,4})"
             };
-        
-        //When
+
+            //When
             var set = new RegexSet(patterns);
-        
-        //Then
+
+            //Then
             Assert.Equal(3, set.Count);
         }
 
         [Fact]
         public void CreateSetWithOptions()
         {
-        //Given
-            var set = new RegexSet(new [] {
+            //Given
+            var set = new RegexSet(new[] {
                 "()",
                 "[]",
                 "."
-            }, new Options{
+            }, new Options
+            {
                 Literal = true,
             });
-        
-        //When
+
+            //When
             var parenMatches = set.Match("I have some () in");
             var dotMatches = set.Match("I am the container of a . dot");
             var bland = set.Match("boring");
 
-        //Then
+            //Then
             Assert.True(parenMatches.Matched);
             Assert.True(dotMatches.Matched);
             Assert.False(bland.Matched);
@@ -48,21 +49,22 @@ namespace IronRe2.Tests
         [Fact]
         public void CreateSetWithBytesOptions()
         {
-        //Given
-            var set = new RegexSet(new [] {
+            //Given
+            var set = new RegexSet(new[] {
                 Encoding.UTF8.GetBytes("()"),
                 Encoding.UTF8.GetBytes("[]"),
                 Encoding.UTF8.GetBytes("."),
-            }, new Options{
+            }, new Options
+            {
                 Literal = true,
             });
-        
-        //When
+
+            //When
             var parenMatches = set.Match("I have some () in");
             var dotMatches = set.Match("I am the container of a . dot");
             var bland = set.Match("boring");
 
-        //Then
+            //Then
             Assert.True(parenMatches.Matched);
             Assert.True(dotMatches.Matched);
             Assert.False(bland.Matched);
@@ -73,7 +75,7 @@ namespace IronRe2.Tests
         {
             var ex = Assert.Throws<RegexCompilationException>(() =>
             {
-                new RegexSet(new [] {
+                new RegexSet(new[] {
                     "I'm OK",
                     ")unmatched]parens",
                 });
@@ -85,17 +87,17 @@ namespace IronRe2.Tests
         [Fact]
         public void RegexSetMatch()
         {
-        //Given
-            var set = new RegexSet(new [] {
+            //Given
+            var set = new RegexSet(new[] {
                 @"\w+", // words
                 @"\d+", // digits
                 @"\d{4}-\d{2}-\d{2}", // dates 
             });
-        
-        //When
-            var matches = set.Match("I have 1 date: 1969-07-11");    
-        
-        //Then
+
+            //When
+            var matches = set.Match("I have 1 date: 1969-07-11");
+
+            //Then
             Assert.True(matches.Matched);
             Assert.Equal(3, matches.MatchCount);
             Assert.Collection(
@@ -109,18 +111,18 @@ namespace IronRe2.Tests
         [Fact]
         public void RegexSetMatchWithBytes()
         {
-        //Given
-            var set = new RegexSet(new [] {
+            //Given
+            var set = new RegexSet(new[] {
                 @"\w+", // words
                 @"\d+", // digits
                 @"\d{4}-\d{2}-\d{2}", // dates 
             });
-        
-        //When
+
+            //When
             var matches = set.Match(
-                Encoding.UTF8.GetBytes("I have 1 date: 1969-07-11"));    
-        
-        //Then
+                Encoding.UTF8.GetBytes("I have 1 date: 1969-07-11"));
+
+            //Then
             Assert.True(matches.Matched);
             Assert.Equal(3, matches.MatchCount);
             Assert.Collection(

--- a/test/IronRe2.Tests/RegexSetTests.cs
+++ b/test/IronRe2.Tests/RegexSetTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Xunit;
 
 namespace IronRe2.Tests
@@ -45,6 +46,29 @@ namespace IronRe2.Tests
         }
 
         [Fact]
+        public void CreateSetWithBytesOptions()
+        {
+        //Given
+            var set = new RegexSet(new [] {
+                Encoding.UTF8.GetBytes("()"),
+                Encoding.UTF8.GetBytes("[]"),
+                Encoding.UTF8.GetBytes("."),
+            }, new Options{
+                Literal = true,
+            });
+        
+        //When
+            var parenMatches = set.Match("I have some () in");
+            var dotMatches = set.Match("I am the container of a . dot");
+            var bland = set.Match("boring");
+
+        //Then
+            Assert.True(parenMatches.Matched);
+            Assert.True(dotMatches.Matched);
+            Assert.False(bland.Matched);
+        }
+
+        [Fact]
         public void RegexSetThrowsWithInvalidPattern()
         {
             var ex = Assert.Throws<RegexCompilationException>(() =>
@@ -70,6 +94,31 @@ namespace IronRe2.Tests
         
         //When
             var matches = set.Match("I have 1 date: 1969-07-11");    
+        
+        //Then
+            Assert.True(matches.Matched);
+            Assert.Equal(3, matches.MatchCount);
+            Assert.Collection(
+                matches.MatchingPatterns,
+                p => Assert.Equal(0, p),
+                p => Assert.Equal(1, p),
+                p => Assert.Equal(2, p));
+        }
+
+
+        [Fact]
+        public void RegexSetMatchWithBytes()
+        {
+        //Given
+            var set = new RegexSet(new [] {
+                @"\w+", // words
+                @"\d+", // digits
+                @"\d{4}-\d{2}-\d{2}", // dates 
+            });
+        
+        //When
+            var matches = set.Match(
+                Encoding.UTF8.GetBytes("I have 1 date: 1969-07-11"));    
         
         //Then
             Assert.True(matches.Matched);

--- a/test/IronRe2.Tests/RegexTests.cs
+++ b/test/IronRe2.Tests/RegexTests.cs
@@ -193,6 +193,32 @@ namespace IronRe2.Tests
         }
 
         [Fact]
+        public void FindWithCapturesBytes()
+        {
+            var pattern = @"(?P<h>hello) (?P<w>world)";
+            var re = new Regex(Encoding.UTF8.GetBytes(pattern));
+
+
+            var captures = re.Captures(
+                Encoding.UTF8.GetBytes("hello world"));
+
+
+            Assert.Equal(3, captures.Count);
+            Assert.True(captures.Matched);
+            Assert.Equal(0, captures.Start);
+            Assert.Equal(11, captures.End);
+            Assert.True(captures[0].Matched);
+            Assert.Equal(0, captures[0].Start);
+            Assert.Equal(11, captures[0].End);
+            Assert.True(captures[1].Matched);
+            Assert.Equal(0, captures[1].Start);
+            Assert.Equal(5, captures[1].End);
+            Assert.True(captures[2].Matched);
+            Assert.Equal(6, captures[2].Start);
+            Assert.Equal(11, captures[2].End);
+        }
+
+        [Fact]
         public void FindWithOptionalCaptures()
         {
             var pattern = @" (.)(.)? ";

--- a/test/IronRe2.Tests/RegexTests.cs
+++ b/test/IronRe2.Tests/RegexTests.cs
@@ -23,41 +23,41 @@ namespace IronRe2.Tests
         [Fact]
         public void RegexCreateWithPatternExposesPattern()
         {
-        //Given
+            //Given
             var regex = new Regex(".+");
 
-        //When
+            //When
             var pattern = regex.Pattern;
 
-        //Then
+            //Then
             Assert.Equal(".+", pattern);
         }
 
         [Fact]
         public void RegexCreateWithOptions()
         {
-        //Given
+            //Given
             var regex = new Regex(@"\n", new Options { NeverNewline = true });
 
-        //When
+            //When
             var match = regex.IsMatch("foo\nbar");
 
-        //Then
+            //Then
             Assert.False(match);
         }
 
         [Fact]
         public void RegexCreateEsposesProgramSize()
         {
-        //Given
+            //Given
             var helloRe = new Regex("hello world");
             var emptyRe = new Regex("");
 
-        //When
+            //When
             var helloSize = helloRe.ProgramSize;
             var emptySize = emptyRe.ProgramSize;
 
-        //Then
+            //Then
             Assert.Equal(15, helloSize);
             Assert.Equal(4, emptySize);
         }
@@ -65,15 +65,15 @@ namespace IronRe2.Tests
         [Fact]
         public void RegexCreateExposesCaptureGroupInfo()
         {
-        //Given
+            //Given
             var regex = new Regex("(.+) (?P<foo>.*)");
 
-        //When
+            //When
             var numCaptures = regex.CaptureGroupCount;
             var fooCaptureId = regex.FindNamedCapture("foo");
             var invalidCaptureId = regex.FindNamedCapture("bar");
-        
-        //Then
+
+            //Then
             Assert.Equal(2, numCaptures);
             Assert.Equal(2, fooCaptureId);
             Assert.Equal(-1, invalidCaptureId);
@@ -107,7 +107,7 @@ namespace IronRe2.Tests
                 Assert.Equal(match, re.IsMatch(haystack));
             }
         }
-        
+
         [Theory]
         [MemberData(nameof(FindData))]
         public void RegexEasyFind(string pattern, string haystack, int start, int end)
@@ -176,19 +176,21 @@ namespace IronRe2.Tests
             var matches = new List<Match>(re.FindAll("hello world"));
 
             Assert.Collection(matches,
-                m => {
+                m =>
+                {
                     Assert.Equal(0, m.Start);
                     Assert.Equal(5, m.End);
                     Assert.Equal("hello", m.ExtractedText);
                 },
-                m => {
+                m =>
+                {
                     Assert.Equal(6, m.Start);
                     Assert.Equal(11, m.End);
                     Assert.Equal("world", m.ExtractedText);
                 });
         }
 
-        [Fact(Timeout=2)]
+        [Fact(Timeout = 2)]
         public void RegexFindAllWithZeroSizedMatch()
         {
             var re = new Regex(@"\b");
@@ -196,32 +198,38 @@ namespace IronRe2.Tests
             var matches = new List<Match>(re.FindAll(" fizz 9 buzz "));
 
             Assert.Collection(matches,
-                m => {
+                m =>
+                {
                     Assert.Equal(1, m.Start);
                     Assert.Equal(1, m.End);
                     Assert.Equal("", m.ExtractedText);
                 },
-                m => {
+                m =>
+                {
                     Assert.Equal(5, m.Start);
                     Assert.Equal(5, m.End);
                     Assert.Equal("", m.ExtractedText);
                 },
-                m => {
+                m =>
+                {
                     Assert.Equal(6, m.Start);
                     Assert.Equal(6, m.End);
                     Assert.Equal("", m.ExtractedText);
                 },
-                m => {
+                m =>
+                {
                     Assert.Equal(7, m.Start);
                     Assert.Equal(7, m.End);
                     Assert.Equal("", m.ExtractedText);
                 },
-                m => {
+                m =>
+                {
                     Assert.Equal(8, m.Start);
                     Assert.Equal(8, m.End);
                     Assert.Equal("", m.ExtractedText);
                 },
-                m => {
+                m =>
+                {
                     Assert.Equal(12, m.Start);
                     Assert.Equal(12, m.End);
                     Assert.Equal("", m.ExtractedText);
@@ -307,23 +315,26 @@ namespace IronRe2.Tests
         public void CaptureNamesReturnesExpectedNames()
         {
             var re = new Regex(@"(unnamed_cap): (?P<year>\d{4})-(?P<month>\d{2})(-)(?P<day>\d{2})");
-            
+
 
             var namedCaps = re.NamedCaptures()
                 .OrderBy(cap => cap.Index)
                 .ToList();
 
-            
+
             Assert.Collection(namedCaps,
-                c => {
+                c =>
+                {
                     Assert.Equal("year", c.Name);
                     Assert.Equal(2, c.Index);
                 },
-                c => {
+                c =>
+                {
                     Assert.Equal("month", c.Name);
                     Assert.Equal(3, c.Index);
                 },
-                c => {
+                c =>
+                {
                     Assert.Equal("day", c.Name);
                     Assert.Equal(5, c.Index);
                 });
@@ -347,7 +358,7 @@ namespace IronRe2.Tests
                 Assert.True(captures[1].Matched);
                 Assert.Equal(37, captures[1].Start);
                 Assert.Equal(41, captures[1].End);
-                
+
                 /// As well as the UTF-8 indices the extracted text is available
                 Assert.True(captures[2].Matched);
                 Assert.Equal("06", captures[2].ExtractedText);

--- a/test/IronRe2.Tests/RegexTests.cs
+++ b/test/IronRe2.Tests/RegexTests.cs
@@ -94,6 +94,18 @@ namespace IronRe2.Tests
                 Assert.Equal(match, re.IsMatch(haystack));
             }
         }
+
+        [Theory]
+        [MemberData(nameof(IsMatchData))]
+        public void RegexBytesIsMatch(string p, string h, bool match)
+        {
+            var pattern = Encoding.UTF8.GetBytes(p);
+            var haystack = Encoding.UTF8.GetBytes(h);
+            using (var re = new Regex(pattern))
+            {
+                Assert.Equal(match, re.IsMatch(haystack));
+            }
+        }
         
         [Theory]
         [MemberData(nameof(FindData))]

--- a/test/IronRe2.Tests/RegexTests.cs
+++ b/test/IronRe2.Tests/RegexTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 using IronRe2;
 using System.Collections.Generic;
 using System.Text;
+using System.Linq;
 
 namespace IronRe2.Tests
 {
@@ -299,6 +300,33 @@ namespace IronRe2.Tests
             Assert.False(captures[2].Matched);
             Assert.Equal(-1, captures[2].Start);
             Assert.Equal(-1, captures[2].End);
+        }
+
+
+        [Fact]
+        public void CaptureNamesReturnesExpectedNames()
+        {
+            var re = new Regex(@"(unnamed_cap): (?P<year>\d{4})-(?P<month>\d{2})(-)(?P<day>\d{2})");
+            
+
+            var namedCaps = re.NamedCaptures()
+                .OrderBy(cap => cap.Index)
+                .ToList();
+
+            
+            Assert.Collection(namedCaps,
+                c => {
+                    Assert.Equal("year", c.Name);
+                    Assert.Equal(2, c.Index);
+                },
+                c => {
+                    Assert.Equal("month", c.Name);
+                    Assert.Equal(3, c.Index);
+                },
+                c => {
+                    Assert.Equal("day", c.Name);
+                    Assert.Equal(5, c.Index);
+                });
         }
 
         [Fact]

--- a/test/IronRe2.Tests/RegexTests.cs
+++ b/test/IronRe2.Tests/RegexTests.cs
@@ -2,6 +2,7 @@ using System;
 using Xunit;
 using IronRe2;
 using System.Collections.Generic;
+using System.Text;
 
 namespace IronRe2.Tests
 {
@@ -115,6 +116,29 @@ namespace IronRe2.Tests
         [MemberData(nameof(FindData))]
         public void RegexFind(string pattern, string haystack, int start, int end)
         {
+            using (var re = new Regex(pattern))
+            {
+                var match = re.Find(haystack);
+                if (start != -1)
+                {
+                    Assert.True(match.Matched);
+                    Assert.Equal(start, match.Start);
+                    Assert.Equal(end, match.End);
+                }
+                else
+                {
+                    Assert.False(match.Matched);
+                }
+            }
+        }
+
+
+        [Theory]
+        [MemberData(nameof(FindData))]
+        public void RegexByteFind(string p, string h, int start, int end)
+        {
+            var pattern = Encoding.UTF8.GetBytes(p);
+            var haystack = Encoding.UTF8.GetBytes(h);
             using (var re = new Regex(pattern))
             {
                 var match = re.Find(haystack);

--- a/test/IronRe2.Tests/RegexTests.cs
+++ b/test/IronRe2.Tests/RegexTests.cs
@@ -168,6 +168,66 @@ namespace IronRe2.Tests
         }
 
         [Fact]
+        public void RegexFindAll()
+        {
+            var re = new Regex(@"\b\w+\b");
+
+            var matches = new List<Match>(re.FindAll("hello world"));
+
+            Assert.Collection(matches,
+                m => {
+                    Assert.Equal(0, m.Start);
+                    Assert.Equal(5, m.End);
+                    Assert.Equal("hello", m.ExtractedText);
+                },
+                m => {
+                    Assert.Equal(6, m.Start);
+                    Assert.Equal(11, m.End);
+                    Assert.Equal("world", m.ExtractedText);
+                });
+        }
+
+        [Fact(Timeout=2)]
+        public void RegexFindAllWithZeroSizedMatch()
+        {
+            var re = new Regex(@"\b");
+
+            var matches = new List<Match>(re.FindAll(" fizz 9 buzz "));
+
+            Assert.Collection(matches,
+                m => {
+                    Assert.Equal(1, m.Start);
+                    Assert.Equal(1, m.End);
+                    Assert.Equal("", m.ExtractedText);
+                },
+                m => {
+                    Assert.Equal(5, m.Start);
+                    Assert.Equal(5, m.End);
+                    Assert.Equal("", m.ExtractedText);
+                },
+                m => {
+                    Assert.Equal(6, m.Start);
+                    Assert.Equal(6, m.End);
+                    Assert.Equal("", m.ExtractedText);
+                },
+                m => {
+                    Assert.Equal(7, m.Start);
+                    Assert.Equal(7, m.End);
+                    Assert.Equal("", m.ExtractedText);
+                },
+                m => {
+                    Assert.Equal(8, m.Start);
+                    Assert.Equal(8, m.End);
+                    Assert.Equal("", m.ExtractedText);
+                },
+                m => {
+                    Assert.Equal(12, m.Start);
+                    Assert.Equal(12, m.End);
+                    Assert.Equal("", m.ExtractedText);
+                });
+        }
+
+        [Fact]
         public void FindWithCaptures()
         {
             var pattern = @"(?P<h>hello) (?P<w>world)";

--- a/test/IronRe2.Tests/RegexTests.cs
+++ b/test/IronRe2.Tests/RegexTests.cs
@@ -301,7 +301,6 @@ namespace IronRe2.Tests
             Assert.Equal(-1, captures[2].End);
         }
 
-
         [Fact]
         public void CapturesWithExtractedText()
         {
@@ -328,6 +327,36 @@ namespace IronRe2.Tests
                 // capture group indices can be looked up by name with th `Regex`
                 Assert.True(captures[re.FindNamedCapture("day")].Matched);
             }
+        }
+
+        [Fact]
+        public void CapturesAllReturnsAllMatches()
+        {
+            var re = new Regex(@"(\w+) (\w+)");
+
+
+            var captures = new List<Captures>(re.CaptureAll("a bee too CD"));
+
+
+            // We are looking for non-overlapping matches so we don't expect
+            // a match on `bee too`.
+            Assert.Collection(captures,
+                c =>
+                {
+                    Assert.True(c.Matched);
+                    Assert.Equal(0, c.Start);
+                    Assert.Equal(5, c.End);
+                    Assert.Equal("a", c[1].ExtractedText);
+                    Assert.Equal("bee", c[2].ExtractedText);
+                },
+                c =>
+                {
+                    Assert.True(c.Matched);
+                    Assert.Equal(6, c.Start);
+                    Assert.Equal(12, c.End);
+                    Assert.Equal("too", c[1].ExtractedText);
+                    Assert.Equal("CD", c[2].ExtractedText);
+                });
         }
 
         public static IEnumerable<object[]> IsMatchData()


### PR DESCRIPTION
Update the FFI delcations and structured API so that clients can search using `byte`s rather
than `string`s.

This adds overloads to the following functions:

 * [x] `Regex::IsMatch`
 * [x] `Regex::Find`
 * [x] `Regex::Captures`
 * [x] `static IsMatch`
 * [x] `static Find`
 * [x] `RegexSet::Match`

Fixes #2

Adds support for search iterator APIs:

 * [x] `Regex::FindAll`
 * [x] `Regex::CaptureAll`

Fixes: #4 