### PR TITLE
Add Nullability Annotations

### DIFF
--- a/src/IronRe2/Captures.cs
+++ b/src/IronRe2/Captures.cs
@@ -9,7 +9,7 @@ namespace IronRe2
     /// </summary>
     public class Captures : Match, IReadOnlyList<Match>
     {
-        private ByteRange[] _ranges;
+        private ByteRange[]? _ranges;
 
         internal Captures()
             : base()
@@ -25,12 +25,15 @@ namespace IronRe2
         /// <summary>
         /// Access the match at the given capture group index
         /// </summary>
-        public Match this[int index] => new Match(_haystack, _ranges[index]);
+        public Match this[int index] =>
+            (index >= 0 && index < Count) ?
+                new Match(_haystack, _ranges![index]) :
+                throw new IndexOutOfRangeException($"No capture group at index {index}");
 
         /// <summary>
         /// Returns the number of groups in this set of captures.
         /// </summary>
-        public int Count => _ranges.Length;
+        public int Count => _ranges?.Length ?? 0;
 
         public IEnumerator<Match> GetEnumerator()
         {

--- a/src/IronRe2/IronRe2.csproj
+++ b/src/IronRe2/IronRe2.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>Latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <nullable>enable</nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IronRe2/NamedCaptureEnumerator.cs
+++ b/src/IronRe2/NamedCaptureEnumerator.cs
@@ -10,6 +10,8 @@ namespace IronRe2
     /// </summary>
     internal class NamedCaptureEnumerator : UnmanagedResource<NamedCaptureIteratorHandle>, IEnumerator<NamedCaptureGroup>
     {
+        private NamedCaptureGroup? _current = null;
+
         public NamedCaptureEnumerator(Regex regex)
             : base(Re2Ffi.cre2_named_groups_iter_new(regex.RawHandle))
         {
@@ -23,8 +25,9 @@ namespace IronRe2
         /// Named capture information, or null if the enumerator isn't pointing
         /// at a valid item.
         /// </value>
-        public NamedCaptureGroup Current { get; private set; }
+        public NamedCaptureGroup Current => _current ?? throw new InvalidOperationException();
 
+        /// <inheritdoc />
         object IEnumerator.Current => Current;
 
 
@@ -38,12 +41,12 @@ namespace IronRe2
             if (Re2Ffi.cre2_named_groups_iter_next(RawHandle, out var namePtr, out var index))
             {
                 var name = Marshal.PtrToStringAnsi(new IntPtr(namePtr));
-                Current = new NamedCaptureGroup(name, index);
+                _current = new NamedCaptureGroup(name, index);
                 return true;
             }
             else
             {
-                Current = null;
+                _current = null;
                 return false;
             }
         }

--- a/src/IronRe2/Regex.cs
+++ b/src/IronRe2/Regex.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -61,7 +61,7 @@ namespace IronRe2
         /// <returns>
         /// The raw handle to the Regex, or throws on compilation failure
         /// </returns>
-        private static RegexHandle Compile(ReadOnlySpan<byte> patternBytes, Options opts)
+        private static RegexHandle Compile(ReadOnlySpan<byte> patternBytes, Options? opts)
         {
             var handle = Re2Ffi.cre2_new(
                 in MemoryMarshal.GetReference(patternBytes), patternBytes.Length,
@@ -211,10 +211,9 @@ namespace IronRe2
         public IEnumerable<Match> FindAll(ReadOnlyMemory<byte> haystack)
         {
             var offset = 0;
-            Match match = null;
             while (true)
             {
-                match = Find(haystack, offset);
+                var match = Find(haystack, offset);
                 if (match.Matched)
                 {
                     offset = match.Start == match.End ?
@@ -320,10 +319,9 @@ namespace IronRe2
         public IEnumerable<Captures> CaptureAll(ReadOnlyMemory<byte> haystack)
         {
             var offset = 0;
-            Captures caps = null;
             while (true)
             {
-                caps = Captures(haystack, offset);
+                var caps = Captures(haystack, offset);
                 if (caps.Matched)
                 {
                     offset = caps.Start == caps.End ?

--- a/src/IronRe2/RegexCompilationException.cs
+++ b/src/IronRe2/RegexCompilationException.cs
@@ -9,7 +9,7 @@ namespace IronRe2
         /// <summary>
         /// Get the offending portion of the regular expression being compiled
         /// </summary>
-        public string OffendingPortion { get; }
+        public string? OffendingPortion { get; }
 
         public RegexCompilationException(string message, string badBit)
             : base(message)

--- a/test/IronRe2.Tests/RegexTests.cs
+++ b/test/IronRe2.Tests/RegexTests.cs
@@ -398,6 +398,23 @@ namespace IronRe2.Tests
                 });
         }
 
+        [Fact]
+        public void CapturesOutOfBounds()
+        {
+        //Given
+            var re = new Regex("\\[([a-z]+)\\]");
+        
+        //When
+            var match = re.Captures("some [test] content");
+        
+        //Then
+            Assert.True(match.Matched);
+            Assert.True(match[0].Matched);
+            Assert.Equal("test", match[1].ExtractedText);
+            Assert.Throws<IndexOutOfRangeException>(() => match[2]);
+            Assert.Throws<IndexOutOfRangeException>(() => match[-2]);
+        }
+
         public static IEnumerable<object[]> IsMatchData()
         {
             yield return new object[] { ".+", "hello world", true };


### PR DESCRIPTION
Enable `nullable` on the `IronRe2` project, and add nullability annotations where required.