### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  # NuGet packages
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 25
+    groups:
+      dotnet:
+        patterns:
+          - "*" # Prefer a single PR per solution update


### PR DESCRIPTION
Adds Dependabot configuration to automate dependency updates for both GitHub Actions and NuGet packages.

### Changes

- Created dependabot.yml with configuration for:
  - **GitHub Actions**: Weekly updates (Wednesdays), grouped together to minimize PR noise
  - **NuGet packages**: Weekly updates (Wednesdays), grouped by solution to prefer a single PR per update

### Benefits

- Automated security and dependency updates
- Reduced maintenance burden for keeping dependencies current
- Grouped updates minimize notification fatigue while maintaining visibility
- Consistent update schedule (weekly on Wednesdays)

### Configuration Details

- GitHub Actions updates limited to 10 open PRs
- NuGet updates limited to 25 open PRs
- All updates within each ecosystem are grouped to reduce the number of PRs created